### PR TITLE
fix allow_metadata_inventory_move so that it doesnt crash

### DIFF
--- a/shaper.lua
+++ b/shaper.lua
@@ -5,7 +5,7 @@
 
 
 -- Balancing output per 1 input block with respect to apparent volume of output shape.
--- All current shapes are added, but shapes not present in this table will still be produced 
+-- All current shapes are added, but shapes not present in this table will still be produced
 -- one at a time — if that is the desired quantity, adding them is not required.
 local output_ratios = {
 	bannerstone = 1,
@@ -38,7 +38,7 @@ local function prepare_formspec (material_name)
 
 	local output = string.gsub(material_name, "^.*:", "facade:")
 
-	local shaper_formspec = 
+	local shaper_formspec =
 
 	"size[8,11;]"..
 	"label[0,0;" .. "Choose shape to produce:" .. "]"..
@@ -66,10 +66,10 @@ local function prepare_formspec (material_name)
 	-- only one such shape exists so far, but more should be easy to add here
 
 	if minetest.registered_nodes[output .. "_corner_bricks"] then
-		shaper_formspec = shaper_formspec .. 
+		shaper_formspec = shaper_formspec ..
 			"item_image_button[0,3.5;1,1;" .. output .. "_corner_bricks" .. ";corner_bricks; ]"
 	end
-	
+
 	-- inventory part
 
 	shaper_formspec = shaper_formspec ..
@@ -83,10 +83,10 @@ local function prepare_formspec (material_name)
 	"listring[current_name;dst]"..
 	"listring[current_player;main]"..
 	"listring[current_name;src]"..
-	"listring[current_player;main]"	
+	"listring[current_player;main]"
 
 	return(shaper_formspec)
-	
+
 end
 
 
@@ -112,7 +112,7 @@ local function update_formspec_put (pos, listname, index, stack, player)
 	if listname ~= "src" then
 		return
 	end
-	
+
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
 	local material_name = stack:get_name()
@@ -136,7 +136,7 @@ local function update_formspec_take (pos, listname, index, stack, player)
 	if listname ~= "src" then
 		return
 	end
-	
+
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
 
@@ -159,7 +159,7 @@ local function check_inventory_put (pos, listname, index, stack, player)
 	if listname ~= "src" then
 		return 0
 	end
-	
+
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
 	local material_name = stack:get_name()
@@ -183,18 +183,22 @@ local function check_inventory_take (pos, listname, index, stack, player)
 	end
 
 	return(stack:get_count())
-	
+
 end
 
 
 local function check_inventory_move (pos, from_list, from_index, to_list, to_index, count, player)
-	
+
 	if protect_inventories and minetest.is_protected(pos, player:get_player_name()) then
 		return 0
 	end
 
-	return(stack:get_count())
-	
+	if from_list ~= "dst" or to_list ~= "dst" then
+		return 0
+	end
+
+	return(count)
+
 end
 
 
@@ -205,8 +209,8 @@ local function form_handler(pos, formname, fields, sender)
 		return
 	end
 
-	if fields.quit then 
-		return 
+	if fields.quit then
+		return
 	end
 
 	local meta = minetest.get_meta(pos)
@@ -218,7 +222,7 @@ local function form_handler(pos, formname, fields, sender)
 
 	local inputstack = inv:get_stack("src", 1)
 	local inputname = inputstack:get_name()
-	
+
 	for shape,_ in pairs(fields) do
 
 		local result = string.gsub(inputname, "^.*:", "facade:") .. "_" .. shape


### PR DESCRIPTION
Currently, the allow_metadata_inventory_move makes reference to an argument from allow_metadata_inventory_take, and results in a crash if you move anything between slots in the machine.